### PR TITLE
Adds license and contact objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * expose schema types which define `parameters` with new `ParameterOrRef` type
 * Adds License object
 * Adds Contact object
+* Derives Default for all structs
 
 # 0.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * expose security definition as an enum type
 * expose schema types which define `parameters` with new `ParameterOrRef` type
+* Adds License object
+* Adds Contact object
 
 # 0.1.5
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 /// top level document
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Spec {
     /// version string
     pub swagger: String,
@@ -33,7 +33,7 @@ pub struct Spec {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Tag {
     pub name: String,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -43,14 +43,14 @@ pub struct Tag {
     pub external_docs: Option<Vec<ExternalDoc>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ExternalDoc {
     pub url: String,
     #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Info {
     #[serde(skip_serializing_if="Option::is_none")]
     pub title: Option<String>,
@@ -67,7 +67,7 @@ pub struct Info {
     pub version: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Contact {
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
@@ -79,7 +79,7 @@ pub struct Contact {
     pub email: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct License {
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
@@ -88,7 +88,7 @@ pub struct License {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operations {
     #[serde(skip_serializing_if="Option::is_none")]
     pub get: Option<Operation>,
@@ -108,7 +108,7 @@ pub struct Operations {
     pub parameters: Option<Vec<ParameterOrRef>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operation {
     #[serde(skip_serializing_if="Option::is_none")]
     pub summary: Option<String>,
@@ -130,7 +130,7 @@ pub struct Operation {
     pub parameters: Option<Vec<ParameterOrRef>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Parameter {
     pub name: String,
     #[serde(rename="in")]
@@ -149,7 +149,7 @@ pub struct Parameter {
     pub format: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Response {
     pub description: String,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -208,7 +208,7 @@ pub enum Security {
 /// the shape and properties of an object.
 ///
 /// This may also contain a `$ref` to another definition
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Schema {
     #[serde(skip_serializing_if="Option::is_none")]
     /// a [JSON reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,7 +33,6 @@ pub struct Spec {
     pub tags: Option<Vec<Tag>>,
 }
 
-
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Tag {
     pub name: String,
@@ -53,11 +52,40 @@ pub struct ExternalDoc {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Info {
-    pub title: String,
-    pub version: String,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub description: Option<String>,
     #[serde(skip_serializing_if="Option::is_none")]
     #[serde(rename="termsOfService")]
     pub terms_of_service: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub contact: Option<Contact>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub license: Option<License>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct Contact {
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub name: Option<String>,
+    // TODO: Make sure the url is a valid URL
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub url: Option<String>,
+    // TODO: Make sure the email is a valid email
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct License {
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub name: Option<String>,
+    // TODO: Make sure the url is a valid URL
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
- Adds license and contact to the info.
- Derives default for structs. When using the structs to serialize into OpenAPI, without default all the entries in each struct need to be specified and some like the Operation struct may be full of many `None`. With default it becomes something like this:
```Rust
             openapi::Schema {
                 schema_type: Some(schema_type_here),
                 properties: Some(properties_here),
                 ..Default::default()  // Everything else is None
             })
```
