### PR TITLE
Deriving Clone for all the structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adds License object
 * Adds Contact object
 * Derives Default for all structs
+* Derives Clone for all structs
 
 # 0.1.5
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 /// top level document
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Spec {
     /// version string
     pub swagger: String,
@@ -33,7 +33,7 @@ pub struct Spec {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Tag {
     pub name: String,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -43,14 +43,14 @@ pub struct Tag {
     pub external_docs: Option<Vec<ExternalDoc>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ExternalDoc {
     pub url: String,
     #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Info {
     #[serde(skip_serializing_if="Option::is_none")]
     pub title: Option<String>,
@@ -67,7 +67,7 @@ pub struct Info {
     pub version: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Contact {
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
@@ -79,7 +79,7 @@ pub struct Contact {
     pub email: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct License {
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
@@ -88,7 +88,7 @@ pub struct License {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operations {
     #[serde(skip_serializing_if="Option::is_none")]
     pub get: Option<Operation>,
@@ -108,7 +108,7 @@ pub struct Operations {
     pub parameters: Option<Vec<ParameterOrRef>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operation {
     #[serde(skip_serializing_if="Option::is_none")]
     pub summary: Option<String>,
@@ -130,7 +130,7 @@ pub struct Operation {
     pub parameters: Option<Vec<ParameterOrRef>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Parameter {
     pub name: String,
     #[serde(rename="in")]
@@ -147,18 +147,21 @@ pub struct Parameter {
     pub param_type: Option<String>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub format: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub description: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Response {
     pub description: String,
     #[serde(skip_serializing_if="Option::is_none")]
     pub schema: Option<Schema>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum ParameterOrRef {
+    #[derive(Default)]
     Parameter {
         name: String,
         #[serde(rename="in")]
@@ -175,13 +178,15 @@ pub enum ParameterOrRef {
         param_type: Option<String>,
         #[serde(skip_serializing_if="Option::is_none")]
         format: Option<String>,
+        #[serde(skip_serializing_if="Option::is_none")]
+        description: Option<String>,
     },
     Ref {
         #[serde(rename="$ref")]
         ref_path: String,
     },
 }
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum Security {
     #[serde(rename="apiKey")]
@@ -208,7 +213,7 @@ pub enum Security {
 /// the shape and properties of an object.
 ///
 /// This may also contain a `$ref` to another definition
-#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Schema {
     #[serde(skip_serializing_if="Option::is_none")]
     /// a [JSON reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)


### PR DESCRIPTION
Allows to do `spec.clone()` .
Maybe I should not need to do this in my code so not sure if this is a good addition or not.

Also, please release 0.1.6 when you can.