### PR TITLE
Fix compilation issue from a33e084 (`Operations` -> `PathItem`)

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -44,7 +44,7 @@ pub struct Spec {
     pub tags: Option<Vec<Tag>>,
     /// Relative paths to the individual endpoints. They must be relative
     /// to the 'basePath'.
-    pub paths: BTreeMap<String, Operations>,
+    pub paths: BTreeMap<String, PathItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub definitions: Option<BTreeMap<String, Schema>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Last commit on `master` (a33e084) breaks compilation:
```
   Compiling openapi v0.1.5 (file:///${HOME}/openapi.git)
error[E0412]: cannot find type `Operations` in this scope
  --> src/schema.rs:47:33
   |
47 |     pub paths: BTreeMap<String, Operations>,
   |                                 ^^^^^^^^^^ did you mean `Operation`?

error[E0412]: cannot find type `Operations` in this scope
```

Looking at a33e084 it seems the `Operations` was renamed to `PathItem`? This commit simply rename `Operations` to `PathItem` for `Spec::paths`.