### PR TITLE
make Parameter.style public too

### DIFF
--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -402,12 +402,12 @@ pub struct Parameter {
     /// value. Default values (based on value of in): for `query` - `form`; for `path` - `simple`; for
     /// `header` - `simple`; for cookie - `form`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    style: Option<ParameterStyle>,
+    pub style: Option<ParameterStyle>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-enum ParameterStyle {
+pub enum ParameterStyle {
     Form,
     Simple,
 }


### PR DESCRIPTION
It's not easy to initialize a `Parameter` if all fields are not public and I think it makes sens to be able to change the style.