### PR TITLE
externalDocs is an object, not a vec

### DIFF
--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -58,7 +58,7 @@ pub struct Spec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security: Option<Vec<BTreeMap<String, Vec<String>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<Vec<ExternalDoc>>,
+    pub external_docs: Option<ExternalDoc>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
@@ -68,7 +68,7 @@ pub struct Tag {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<Vec<ExternalDoc>>,
+    pub external_docs: Option<ExternalDoc>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]


### PR DESCRIPTION
- https://swagger.io/specification/v2/#externalDocumentationObject
- https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v2.0/json/petstore-with-external-docs.json#L18-L21
- https://idratherbewriting.com/learnapidoc/pubapis_openapi_step8_externaldocs_object.html