### PR TITLE
Enhancements for openapi spec support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,26 +17,26 @@ branches:
   only:
   - master
 
-install: |
-  # see https://github.com/xd009642/tarpaulin/issues/150 for tarpaulin nightly dependency
-  if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin -f
-    # should only be necessary until rustfmt produces consistent results in stable/nightly
-    rustup component add rustfmt
-  fi
+install:
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+      cargo install cargo-tarpaulin -f
+      rustup component add rustfmt
+    fi
 script:
-- |
-   if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-     cargo fmt --all -- --check
-   fi
-- cargo test
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+      cargo fmt --all -- --check
+    fi
+  - cargo test
 
 # Cache `cargo install`ed tools, but don't cache the project's `target`
 # directory (which ends up over-caching and filling all disk space!)
 # https://levans.fr/rust_travis_cache.html
 cache:
   directories:
-    - /home/travis/.cargo
+    - $HOME/.cargo
+    - $HOME/.rustup
 
 before_cache:
   # But don't cache the cargo registry
@@ -54,7 +54,7 @@ after_success:
   # report coverage to coveralls
   # see https://github.com/xd009642/tarpaulin for more information
   - '[ $TRAVIS_EVENT_TYPE != "cron" ] &&
-    [ $TRAVIS_RUST_VERSION = nightly ] &&
+    [ $TRAVIS_RUST_VERSION = stable ] &&
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
     cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID || true'

--- a/data/v3.0/petstore-expanded.yaml
+++ b/data/v3.0/petstore-expanded.yaml
@@ -153,3 +153,24 @@ components:
           format: int32
         message:
           type: string
+
+    PetSpecies:
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+
+    Dog:
+      properties:
+        name:
+          type: string
+        age:
+          type: int
+
+    Cat:
+      properties:
+        name:
+          type: string
+        age:
+          type: int
+        lives:
+          type: int

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,11 +98,8 @@ mod tests {
     };
 
     /// Helper function to write string to file.
-    fn write_to_file<P>(
-        path: P,
-        filename: &str,
-        data: &str,
-    ) where
+    fn write_to_file<P>(path: P, filename: &str, data: &str)
+    where
         P: AsRef<Path> + std::fmt::Debug,
     {
         println!("    Saving string to {:?}...", path);
@@ -230,6 +227,23 @@ mod tests {
                 "contents did not match for api {}",
                 api_filename
             );
+        }
+    }
+
+    #[test]
+    fn can_deserialize_one_of_v3() {
+        let openapi = from_path("data/v3.0/petstore-expanded.yaml").unwrap();
+        if let OpenApi::V3_0(spec) = openapi {
+            let components = spec.components.unwrap();
+            let schemas = components.schemas.unwrap();
+            let obj_or_ref = schemas.get("PetSpecies");
+
+            if let Some(v3_0::ObjectOrReference::Object(schema)) = obj_or_ref {
+                // there should be 2 schemas in there
+                assert_eq!(schema.one_of.as_ref().unwrap().len(), 2);
+            } else {
+                panic!("object should have been schema");
+            }
         }
     }
 }

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -3,7 +3,7 @@
 use semver;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::collections::{HashMap, BTreeMap};
+use std::collections::{BTreeMap, HashMap};
 use url;
 use url_serde;
 
@@ -549,6 +549,12 @@ pub struct Schema {
     /// [not](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#not)
     #[serde(rename = "not", skip_serializing_if = "Option::is_none")]
     pub not: Option<Vec<ObjectOrReference<Schema>>>,
+
+    #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<u32>,
+
+    #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<u32>,
 
     /// [Specification extensions](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specificationExtensions)
     #[serde(flatten)]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -3,7 +3,7 @@
 use semver;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::collections::BTreeMap;
+use std::collections::{HashMap, BTreeMap};
 use url;
 use url_serde;
 
@@ -549,6 +549,10 @@ pub struct Schema {
     /// [not](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#not)
     #[serde(rename = "not", skip_serializing_if = "Option::is_none")]
     pub not: Option<Vec<ObjectOrReference<Schema>>>,
+
+    /// [Specification extensions](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specificationExtensions)
+    #[serde(flatten)]
+    pub extensions: HashMap<String, String>,
 }
 
 /// Describes a single response from an API Operation, including design-time, static `links`

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -528,8 +528,27 @@ pub struct Schema {
 
     /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
     /// JSON Schema.
+    /// [allOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof)
     #[serde(rename = "allOf", skip_serializing_if = "Option::is_none")]
     pub all_of: Option<Vec<ObjectOrReference<Schema>>>,
+
+    /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
+    /// JSON Schema.
+    /// [oneOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#oneof)
+    #[serde(rename = "oneOf", skip_serializing_if = "Option::is_none")]
+    pub one_of: Option<Vec<ObjectOrReference<Schema>>>,
+
+    /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
+    /// JSON Schema.
+    /// [anyOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#anyof)
+    #[serde(rename = "anyOf", skip_serializing_if = "Option::is_none")]
+    pub any_of: Option<Vec<ObjectOrReference<Schema>>>,
+
+    /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
+    /// JSON Schema.
+    /// [not](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#not)
+    #[serde(rename = "not", skip_serializing_if = "Option::is_none")]
+    pub not: Option<Vec<ObjectOrReference<Schema>>>,
 }
 
 /// Describes a single response from an API Operation, including design-time, static `links`


### PR DESCRIPTION
Added to schema (from openapi 3 spec)
* oneOf, anyOf, not
* maxLength, minLength
* extensions map: this map will include all additional fields that are defined in the model. This field is flattened so serialization/deserialization works as intended

Fixed failing travis build job