### PR TITLE
Adds missing possible style variants.

### DIFF
--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -408,8 +408,13 @@ pub struct Parameter {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 enum ParameterStyle {
+    Matrix,
+    Label,
     Form,
     Simple,
+    SpaceDelimited,
+    PipeDelimited,
+    DeepObject,
 }
 
 // FIXME: Verify against OpenAPI 3.0


### PR DESCRIPTION
According to the v3 specification, parameter styles can include a range of values not currently present in `openapi::v3_0::schema::ParameterStyle`.