### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-error-chain = "0.10"
 failure = "0.1"
 semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
+thiserror = "1.0"
 url = { version = "2.0", features = ["serde"] }
 
 [dev-dependencies]
+anyhow = "1.0"
 pretty_assertions = "0.6"
 serde_test = "1.0.117"

--- a/examples/printer.rs
+++ b/examples/printer.rs
@@ -1,43 +1,17 @@
-use failure::Fail;
-use std::{io::Write, process::exit};
+use anyhow::Result;
 
-fn main() {
+fn main() -> Result<()> {
     if let Some(path) = std::env::args().nth(1) {
-        match openapi::from_path(path) {
-            Ok(spec) => {
-                /*for (path, op) in spec.paths {
-                    println!("{}", path);
-                    println!("{:#?}", op);
-                }
-                for (name, definition) in spec.definitions {
-                    println!("{}", name);
-                    println!("{:#?}", definition);
-                }*/
-                println!("{}", openapi::to_json(&spec).unwrap());
-            }
-            Err(e) => {
-                let stderr = &mut ::std::io::stderr();
-                let errmsg = "Error writing to stderr";
-
-                writeln!(stderr, "error: {}", e).expect(errmsg);
-                for cause in Fail::iter_chain(&e) {
-                    writeln!(
-                        stderr,
-                        "caused by: {} {}",
-                        cause.name().unwrap_or("Error"),
-                        cause
-                    )
-                    .expect(errmsg);
-                }
-
-                // The backtrace is not always generated. Try to run this example
-                // with `RUST_BACKTRACE=1`.
-                if let Some(backtrace) = e.cause().and_then(|cause| cause.backtrace()) {
-                    writeln!(stderr, "backtrace: {:?}", backtrace).expect(errmsg);
-                }
-
-                exit(1);
-            }
+        let spec = openapi::from_path(path)?;
+        /*for (path, op) in spec.paths {
+            println!("{}", path);
+            println!("{:#?}", op);
         }
+        for (name, definition) in spec.definitions {
+            println!("{}", name);
+            println!("{:#?}", definition);
+        }*/
+        println!("{}", openapi::to_json(&spec)?);
     }
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,46 +1,22 @@
 //! Error types
 
-use failure::Fail;
 use semver::{SemVerError, Version};
 use serde_json::Error as JsonError;
 use serde_yaml::Error as YamlError;
 use std::io::Error as IoError;
+use thiserror::Error;
 
 /// errors that openapi functions may return
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    #[fail(display = "{}", _0)]
-    Io(IoError),
-    #[fail(display = "{}", _0)]
-    Yaml(YamlError),
-    #[fail(display = "{}", _0)]
-    Serialize(JsonError),
-    #[fail(display = "{}", _0)]
-    SemVerError(SemVerError),
-    #[fail(display = "Unsupported spec file version ({})", _0)]
+    #[error("I/O error")]
+    Io(#[from] IoError),
+    #[error("YAML serialization or deserialization error")]
+    Yaml(#[from] YamlError),
+    #[error("JSON serialization error")]
+    Serialize(#[from] JsonError),
+    #[error("Semantic Versioning parsing error")]
+    SemVerError(#[from] SemVerError),
+    #[error("Unsupported spec file version ({0})")]
     UnsupportedSpecFileVersion(Version),
-}
-
-impl From<IoError> for Error {
-    fn from(e: IoError) -> Self {
-        Error::Io(e)
-    }
-}
-
-impl From<YamlError> for Error {
-    fn from(e: YamlError) -> Self {
-        Error::Yaml(e)
-    }
-}
-
-impl From<JsonError> for Error {
-    fn from(e: JsonError) -> Self {
-        Error::Serialize(e)
-    }
-}
-
-impl From<SemVerError> for Error {
-    fn from(e: SemVerError) -> Self {
-        Error::SemVerError(e)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,9 @@
 //!
 //! # Errors
 //!
-//! Operations typically result in a `openapi::Result` Type which is an alias
-//! for Rust's
-//! built-in Result with the Err Type fixed to the
-//! [openapi::errors::Error](errors/struct.Error.html) enum type.
+//! Operations typically result in a [`Result`] type, an alias for
+//! [`std::result::Result`] with the `Err` type fixed to [`Error`],
+//! which implements [`std::error::Error`].
 //!
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Read, path::Path, result::Result as StdResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,7 @@
 //! Operations typically result in a `openapi::Result` Type which is an alias
 //! for Rust's
 //! built-in Result with the Err Type fixed to the
-//! [openapi::errors::Error](errors/struct.Error.html) enum type. These are
-//! provided
-//! using [error_chain](https://github.com/brson/error-chain) crate so their
-//! shape and behavior should be consistent and familiar to existing
-//! error_chain users.
+//! [openapi::errors::Error](errors/struct.Error.html) enum type.
 //!
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Read, path::Path, result::Result as StdResult};


### PR DESCRIPTION
[The `failure` crate appears to be deprecated these days](https://nick.groenen.me/posts/rust-error-handling/) and has drawbacks including incompatibilities with `std::error::Error`. For users, it might be inconvenient to have to deal with error types that don’t implement `std::error::Error`.

For this reason, this replaces the `failure` crate entirely. In the library part, `thiserror` is used instead, which also makes the generation of the error type short and convenient (even taking care of the `From` implementations), without exposing any `thiserror` specifics to the user.

In the example, `anyhow` now takes care of printing nicely formatted error messages, including error causes and (if provided with `RUST_BACKTRACE=1`) an error backtrace.

Also, the `error-chain` dependency isn’t used anymore, so let’s remove it.

