### PR TITLE
Update url to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ semver = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
-url = "1.7"
-url_serde = "0.2"
+url = { version = "2.0", features = ["serde"] }
 
 [dev-dependencies]
 pretty_assertions = "0.5"

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -5,8 +5,7 @@ use semver;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::{BTreeMap, HashMap};
-use url;
-use url_serde;
+use url::Url;
 
 use crate::{
     v3_0::components::{Components, ObjectOrReference},
@@ -110,16 +109,6 @@ pub struct Info {
     /// The license information for the exposed API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
-}
-
-/// Wraper around `url::Url` to fix serde issue
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct Url(#[serde(with = "url_serde")] url::Url);
-
-impl Url {
-    pub fn parse<S: AsRef<str>>(input: S) -> std::result::Result<Url, url::ParseError> {
-        url::Url::parse(input.as_ref()).map(Url)
-    }
 }
 
 /// Contact information for the exposed API.


### PR DESCRIPTION
As `url` now has built-in `serde` support via a feature flag, the `url_serde` dependency can be dropped. Also, the URL wrapper type is no longer necessary.