### PR TITLE
Update semver to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 error-chain = "0.10"
 failure = "0.1"
-semver = "0.9"
+semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"


### PR DESCRIPTION
It seems that none of the changes between `semver` 0.9 and 0.11 affect this crate, so bumping the version should be enough.