### PR TITLE
Update pretty_assertions to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ url = "1.7"
 url_serde = "0.2"
 
 [dev-dependencies]
-pretty_assertions = "0.5"
+pretty_assertions = "0.6"
 serde_test = "1.0.117"


### PR DESCRIPTION
It seems that none of the changes between `pretty_assertions` 0.5 and 0.6 affect this crate, so bumping the version should be enough.