### PR TITLE
Allow additionalProperties to take Boolean values

### DIFF
--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -14,6 +14,17 @@ pub enum ObjectOrReference<T> {
     },
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum BooleanObjectOrReference<T> {
+    Boolean(bool),
+    Object(T),
+    Ref {
+        #[serde(rename = "$ref")]
+        ref_path: String,
+    },
+}
+
 /// Holds a set of reusable objects for different aspects of the OAS.
 ///
 /// All objects defined within the components object will have no effect on the API unless

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -9,7 +9,7 @@ use url;
 use url_serde;
 
 use crate::{
-    v3_0::components::{Components, ObjectOrReference},
+    v3_0::components::{BooleanObjectOrReference, Components, ObjectOrReference},
     Error, Result, MINIMUM_OPENAPI30_VERSION,
 };
 
@@ -471,7 +471,6 @@ pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
-    // FIXME: Why can this be a "boolean" (as per the spec)? It doesn't make sense. Here it's not.
     /// Value can be boolean or object. Inline or referenced schema MUST be of a
     /// [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#schemaObject)
     /// and not a standard JSON Schema.
@@ -481,7 +480,7 @@ pub struct Schema {
         skip_serializing_if = "Option::is_none",
         rename = "additionalProperties"
     )]
-    pub additional_properties: Option<ObjectOrReference<Box<Schema>>>,
+    pub additional_properties: Option<BooleanObjectOrReference<Box<Schema>>>,
 
     /// A free-form property to include an example of an instance for this schema.
     /// To represent examples that cannot be naturally represented in JSON or YAML,


### PR DESCRIPTION
The OpenAPI specification defines the `additionalProperties` field according to the JSON schema specification. In the version of the JSON schema specification referenced by the OpenAPI specification, [the value of `additionalProperties` may be either Boolean or a schema](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.18) (though it appears that [newer versions of the JSON schema specification no longer allow Boolean values](https://json-schema.org/draft/2019-09/json-schema-core.html#additionalProperties)).

However, to comply with OpenAPI 3.0, this adjusts the representation of the `additionalProperties` field in this crate accordingly