### PR TITLE
Fixed the data structure for OpenApi 3

### DIFF
--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -6,24 +6,24 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Ref {
+    #[serde(rename = "$ref")]
+    pub ref_path: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum ObjectOrReference<T> {
+    Ref(Ref),
     Object(T),
-    Ref {
-        #[serde(rename = "$ref")]
-        ref_path: String,
-    },
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum BooleanObjectOrReference<T> {
+    Ref(Ref),
     Boolean(bool),
     Object(T),
-    Ref {
-        #[serde(rename = "$ref")]
-        ref_path: String,
-    },
 }
 
 /// Holds a set of reusable objects for different aspects of the OAS.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -2,6 +2,7 @@
 
 use crate::v3_0::extension::Extensions;
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 use std::collections::{BTreeMap, HashMap};
 use url::Url;
 
@@ -441,16 +442,16 @@ pub struct Schema {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "enum")]
-    pub enum_values: Option<Vec<String>>,
+    pub enum_values: Option<Vec<Value>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Box<Schema>>,
+    pub items: Option<Box<ObjectOrReference<Schema>>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub properties: Option<BTreeMap<String, Schema>>,
+    pub properties: Option<BTreeMap<String, ObjectOrReference<Schema>>>,
 
     #[serde(skip_serializing_if = "Option::is_none", rename = "readOnly")]
     pub read_only: Option<bool>,


### PR DESCRIPTION
1. Enums can hold any value: boolean, strings, numbers...so just use JsonValue
2. Items can point to Ref so wrap Schema inside ObjectOrReference
3. Reorder ObjectOrReference because they are untagged, its better to check for Ref first

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>