### PR TITLE
More support for deprecation

### DIFF
--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -168,6 +168,8 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Vec<ParameterOrRef>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub security: Option<Vec<SecurityRequirement>>,
 }
 

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -363,6 +363,8 @@ pub struct Parameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<Schema>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "uniqueItems")]
@@ -478,6 +480,9 @@ pub struct Schema {
     ///       [`serde_json::Value`](https://docs.serde.rs/serde_json/value/enum.Value.html). [spec][https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#data-types]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::value::Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,


### PR DESCRIPTION
Added:

* Support for deprecated operations in V2
  * see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-5
* Support for deprecated parameters in V3
  * see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-10
* Support for deprecated schemas in V3
  * see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-20