### PR TITLE
Remove `failure` crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
 semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Commit e2d506c ("Replace failure dependency with thiserror/anyhow")
already replaced the use of obsolete failure crate, but let's also
remove it from dependencies.