### PR TITLE
Upgrade `pretty-assertions` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ url = { version = "2.0", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"
-pretty_assertions = "0.6"
+pretty_assertions = "1.2.1"
 serde_test = "1.0.117"


### PR DESCRIPTION
The current version we depend on uses the obsolete `difference` crate so
let's upgrade `pretty-assertions` to the latest version.