### PR TITLE
Add deprecated field to Schema object

### DIFF
--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -523,6 +523,9 @@ pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none", rename = "minProperties")]
     pub min_properties: Option<u32>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     // The following properties are taken from the JSON Schema definition but their
     // definitions were adjusted to the OpenAPI Specification.
     // - type - Value MUST be a string. Multiple types via an array are not supported.


### PR DESCRIPTION
This PR add `deprecated` field (which presents in [specification](https://swagger.io/specification/#schema-object)) to `Schema` object.